### PR TITLE
Allow no template_config

### DIFF
--- a/src/py/litestar_vite/plugin.py
+++ b/src/py/litestar_vite/plugin.py
@@ -128,20 +128,15 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
         """
         from litestar_vite.loader import render_asset_tag, render_hmr_client
 
-        if app_config.template_config is None:  # pyright: ignore[reportUnknownMemberType]
-            msg = "A template configuration is required for Vite."
-            raise ImproperlyConfiguredException(msg)
-        if not isinstance(app_config.template_config.engine_instance, JinjaTemplateEngine):  # pyright: ignore[reportUnknownMemberType]
-            msg = "Jinja2 template engine is required for Vite."
-            raise ImproperlyConfiguredException(msg)
-        app_config.template_config.engine_instance.register_template_callable(  # pyright: ignore[reportUnknownMemberType]
-            key="vite_hmr",
-            template_callable=render_hmr_client,
-        )
-        app_config.template_config.engine_instance.register_template_callable(  # pyright: ignore[reportUnknownMemberType]
-            key="vite",
-            template_callable=render_asset_tag,
-        )
+        if app_config.template_config and isinstance(app_config.template_config.engine_instance, JinjaTemplateEngine):  # pyright: ignore[reportUnknownMemberType]
+            app_config.template_config.engine_instance.register_template_callable(  # pyright: ignore[reportUnknownMemberType]
+                key="vite_hmr",
+                template_callable=render_hmr_client,
+            )
+            app_config.template_config.engine_instance.register_template_callable(  # pyright: ignore[reportUnknownMemberType]
+                key="vite",
+                template_callable=render_asset_tag,
+            )
         if self._config.set_static_folders:
             static_dirs = [Path(self._config.bundle_dir), Path(self._config.resource_dir)]
             if Path(self._config.public_dir).exists() and self._config.public_dir != self._config.bundle_dir:

--- a/src/py/litestar_vite/plugin.py
+++ b/src/py/litestar_vite/plugin.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Iterator, cast
 
 from litestar.cli._utils import console
 from litestar.contrib.jinja import JinjaTemplateEngine
-from litestar.exceptions import ImproperlyConfiguredException
 from litestar.plugins import CLIPlugin, InitPluginProtocol
 from litestar.static_files import create_static_files_router  # pyright: ignore[reportUnknownVariableType]
 


### PR DESCRIPTION
Allowing no template_config enables you to use litestar-vite with html frameworks other than `Jinja2`.